### PR TITLE
Remove log heartbeat

### DIFF
--- a/get_data.php
+++ b/get_data.php
@@ -22,7 +22,5 @@
 
 	NewHumbleTitlesToMySQL();
 
-	GetLog ($GLOBALS['getlog_done']);
-
 	mysqli_close ($GLOBALS['link']);
 ?>


### PR DESCRIPTION
This is only useful for damage assessment after an incident, and incidents are rare enough to not justify the debug information.
I'm in favor of there being error checks everywhere needed instead of logging on normal operation.
